### PR TITLE
Fix HTML errors/warnings

### DIFF
--- a/src/main/scripts/build.js
+++ b/src/main/scripts/build.js
@@ -92,14 +92,8 @@ const pages = [
     "pageOrder": 3
   },
   {
-    "pageType": "menuBreak",
-    "pageTemplate": "#",
-    "pageTitle": "Collapse Sections",
-    "menuLevel": 1
-  },
-  {
-    "pageType": "menuBreak",
-    "pageTemplate": "#",
+    "pageType": "menuCollapse",
+    "pageTemplate": "namingconvention",
     "pageTitle": "Naming Convention",
     "menuLevel": 2
   },
@@ -283,14 +277,14 @@ const pages = [
     "pageOrder": 19
   },
   {
-    "pageType": "menuBreakEnd",
-    "pageTemplate": "#",
+    "pageType": "menuCollapseEnd",
+    "pageTemplate": "namingconvention",
     "pageTitle": "Naming Convention End",
     "menuLevel": 2
   },
   {
-    "pageType": "menuBreak",
-    "pageTemplate": "#",
+    "pageType": "menuCollapse",
+    "pageTemplate": "metadataregistry",
     "pageTitle": "Metadata Registry",
     "menuLevel": 2
   },
@@ -341,16 +335,10 @@ const pages = [
     "pageOrder": 23
   },
   {
-    "pageType": "menuBreakEnd",
-    "pageTemplate": "#",
+    "pageType": "menuCollapseEnd",
+    "pageTemplate": "metadataregistry",
     "pageTitle": "Metadata Registry End",
     "menuLevel": 2
-  },
-  {
-    "pageType": "menuBreakEnd",
-    "pageTemplate": "#",
-    "pageTitle": "Collapse Sections End",
-    "menuLevel": 1
   },
   {
     "pageType": "descriptiveText",
@@ -484,6 +472,11 @@ async function buildPage ({ pageTemplate, pageType, idType, pageTitle, schemaBui
         return options.fn(this); 
       }
       return options.inverse(this);
+    });
+
+    hb.registerHelper('stripillegalChars', function (a, b, options) {
+      var cleanString = a.replace(/([^a-z0-9]+)/gi, '');
+      return cleanString
     });
 
     const pageNumtoTemplate = {}

--- a/src/main/templates/audioconfigs.hbs
+++ b/src/main/templates/audioconfigs.hbs
@@ -10,11 +10,11 @@
               <tr>
                 <th scope="col" class="align-text-top sort-column">#</th>
                 <th scope="col" class="align-text-top">DCNC Code<br><small>(For CTT)</small></th>
-                <th scope="col" class="align-text-top" width="10%">Description</th>
+                <th scope="col" class="align-text-top col-2">Description</th>
                 <th scope="col" class="align-text-top">MCATagSymbol Value<br><small>(For DCP Metadata)</small></th>
                 <th scope="col" class="align-text-top">MainSoundConfiguration Tag<br><small>(For DCP Metadata)</small></th>
-                <th scope="col" class="align-text-top" width="30%">CompositionMetadataAsset Extension<br><small>(For DCP Metadata)</small></th>
-                <th scope="col" class="align-text-top" width="15%">Metadata Defining Document(s)</th>
+                <th scope="col" class="align-text-top col-4">CompositionMetadataAsset Extension<br><small>(For DCP Metadata)</small></th>
+                <th scope="col" class="align-text-top col-2">Metadata Defining Document(s)</th>
                 <th scope="col" class="align-text-top">Notes</th>
               </tr>
             </thead>

--- a/src/main/templates/contentmodifiers.hbs
+++ b/src/main/templates/contentmodifiers.hbs
@@ -9,20 +9,20 @@
             <thead class="thead-light">
               <tr>
                 <th scope="col" class="align-text-top">#</th>
-                <th scope="col" class="align-text-top" width="15%">DCNC Content Modifier Value<br><small>(For CTT)</small></th>
+                <th scope="col" class="align-text-top">DCNC Content Modifier Value<br><small>(For CTT)</small></th>
                 <th scope="col" class="align-text-top">Description</th>
-                <th scope="col" class="align-text-top" width="30%">CPL Metadata Sample/Values</th>
-                <th scope="col" class="align-text-top" width="15%">>Metadata Defining Document(s)</th>
+                <th scope="col" class="align-text-top col-4">CPL Metadata Sample/Values</th>
+                <th scope="col" class="align-text-top col-2">Metadata Defining Document(s)</th>
               </tr>
             </thead>
             <tbody id="searchTable">
               {{#data}}
-              <tr id="{{../idType}}-{{dcncCode}}">
-                <td class="">
+              <tr id="{{../idType}}-{{stripillegalChars dcncCode}}">
+                <td>
                   {{dcncSortOrder}}
                 </td>
                 <td class="code">
-                  <a class="anchor" id="{{dcncCode}}" href="#{{dcncCode}}"></a><code>{{dcncCode}}</code>
+                  <a class="anchor" id="{{stripillegalChars dcncCode}}" href="#{{stripillegalChars dcncCode}}"></a><code>{{dcncCode}}</code>
                 </td>
                 <td>
                   {{description}}

--- a/src/main/templates/contenttypes.hbs
+++ b/src/main/templates/contenttypes.hbs
@@ -10,7 +10,7 @@
               <tr>
                 <th scope="col" class="align-text-top sort-column">#</th>
                 <th scope="col" class="align-text-top">DCNC Code<br><small>(For CTT)</small></th>
-                <th scope="col" class="align-text-top" width="30%">Description</th>
+                <th scope="col" class="align-text-top col-2">Description</th>
                 <th scope="col" class="align-text-top">ContentKind Value<br><small>(For DCP Metadata)</small></th>
                 <th scope="col" class="align-text-top">ContentKind Scope<br><small>(For DCP Metadata)</small></th>
                 <th scope="col" class="align-text-top">ContentKind Defining Document(s)</th>

--- a/src/main/templates/cplmetadataexts.hbs
+++ b/src/main/templates/cplmetadataexts.hbs
@@ -8,16 +8,16 @@
           <table id="sorttable" class="table table-small table-hover display">
             <thead class="thead-light">
               <tr>
-                <th scope="col" class="align-text-top">Description</th>
-                <th scope="col" class="align-text-top" width="45%">CompositionMetadataAsset Extension</th>
-                <th scope="col" class="align-text-top" width="15%">Defining Document(s)</th>
+                <th scope="col" class="align-text-top col-2">Description</th>
+                <th scope="col" class="align-text-top col-6">CompositionMetadataAsset Extension</th>
+                <th scope="col" class="align-text-top">Defining Document(s)</th>
                 <th scope="col" class="align-text-top">Contact Info</th>
                 <th scope="col" class="align-text-top">Notes</th>
               </tr>
             </thead>
             <tbody id="searchTable">
               {{#data}}
-              <tr id="{{../idType}}">
+              <tr id="{{../idType}}-{{stripillegalChars description}}">
                 <td>
                   {{description}}
                 </td>

--- a/src/main/templates/facilities.hbs
+++ b/src/main/templates/facilities.hbs
@@ -8,8 +8,8 @@
           <table id="sorttable" class="table table-small table-hover display">
             <thead class="thead-light">
               <tr>
-                <th scope="col" class="align-text-top" width="4em">Code</th>
-                <th scope="col" class="align-text-top">Description</th>
+                <th scope="col" class="align-text-top col-1">Code</th>
+                <th scope="col" class="align-text-top col-4">Description</th>
                 <th scope="col" class="align-text-top">Contact Info</th>
               </tr>
             </thead>

--- a/src/main/templates/kdmforensicflags.hbs
+++ b/src/main/templates/kdmforensicflags.hbs
@@ -9,14 +9,14 @@
             <thead class="thead-light">
               <tr>
                 <th scope="col" class="align-text-top">Description</th>
-                <th scope="col" class="align-text-top" width="45%">URI</th>
-                <th scope="col" class="align-text-top" width="15%">Defining Document(s)</th>
+                <th scope="col" class="align-text-top col-6">URI</th>
+                <th scope="col" class="align-text-top col-2">Defining Document(s)</th>
                 <th scope="col" class="align-text-top">Notes</th>
               </tr>
             </thead>
             <tbody id="searchTable">
               {{#data}}
-              <tr id="{{../idType}}">
+              <tr id="{{../idType}}-{{stripillegalChars uri}}">
                 <td>
                   {{description}}
                 </td>

--- a/src/main/templates/languages.hbs
+++ b/src/main/templates/languages.hbs
@@ -14,7 +14,7 @@
                 <th scope="col" class="align-text-top">DCNC Language</th>
                 <th scope="col" class="align-text-top">Obsoleted DCNC Code(s)<br><small>(Not for use, only listed for historical purposes)</small></th>
                 <th scope="col" class="align-text-top">Usage</th>
-                <th scope="col" class="align-text-top text-wrap" width="20%">Notes</th>
+                <th scope="col" class="align-text-top text-wrap">Notes</th>
               </tr>
             </thead>
             <tbody id="searchTable">

--- a/src/main/templates/partials/footer.hbs
+++ b/src/main/templates/partials/footer.hbs
@@ -4,28 +4,27 @@
       </div>
       {{>pagination}}
     </div>
-  </div>
   <footer class="page-footer font-small">
     <div class="row d-flex align-items-center text-center p-3">
       <div class="col text-center">
         <small class="text-muted">
           Registry version: <code>{{version}}</code>
           <br>Site version: <code>{{site_version}}</code>
-          <p class="text-center">Generated on {{date}}
+          <br>Generated on {{date}}
         </small>
       </div>
     </div>
     <div class="footer-copyright text-center py-2 bg-white">
       <small class="text-muted">
-        <p>
-          ALL DOCUMENTS AND INFORMATION PRESENTED HERE ARE TO BE USED AT YOUR OWN RISK, STRICTLY VOLUNTARY, <br>SHOULD NOT BE USED FOR IMPLEMENTING PRODUCTS, NO WARRANTY EXPRESSED OR IMPLIED. PROVIDED FOR CONVENIENCE ONLY.
-          <br>:: CONTACT: <a href="mailto:INFO@ISDCF.COM">INFO@ISDCF.COM</a> OR <a href="https://github.com/ISDCF/registries-site/issues" target="_blank">https://github.com/ISDCF/registries-site/issues</a> TO OFFER SUGGESTIONS/CORRECTIONS. ::
-          <br>USE AT YOUR OWN RISK
-        </p>
-        <p>
-          © 2020 Copyright: <a href="https://isdcf.com/">ISDCF.com</a>
-        </p>
+        ALL DOCUMENTS AND INFORMATION PRESENTED HERE ARE TO BE USED AT YOUR OWN RISK, STRICTLY VOLUNTARY, <br>SHOULD NOT BE USED FOR IMPLEMENTING PRODUCTS, NO WARRANTY EXPRESSED OR IMPLIED. PROVIDED FOR CONVENIENCE ONLY.
+        <br>:: CONTACT: <a href="mailto:INFO@ISDCF.COM">INFO@ISDCF.COM</a> OR <a href="https://github.com/ISDCF/registries-site/issues" target="_blank">https://github.com/ISDCF/registries-site/issues</a> TO OFFER SUGGESTIONS/CORRECTIONS. ::
+        <br>USE AT YOUR OWN RISK
+      </small>
+    <div class="footer-copyright text-center py-2 bg-white">
+      <small class="text-muted">
+        © 2020 Copyright: <a href="https://isdcf.com/">ISDCF.com</a>
       </small>
     </div>
+  </div>
   </footer> 
 </body>

--- a/src/main/templates/partials/header.hbs
+++ b/src/main/templates/partials/header.hbs
@@ -12,33 +12,33 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" crossorigin="anonymous"></script>
-  <script type="application/javascript" src="{{#ifnoteq pageTemplate "index"}}../{{/ifnoteq}}features.js"></script>
+  <script src="{{#ifnoteq pageTemplate "index"}}../{{/ifnoteq}}features.js"></script>
   <script src="https://code.jquery.com/jquery-3.5.1.js"></script>
   <script src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js"></script>
 </head>
 <body>
   <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom d-flex d-print-none">
-    <a class="navbar-brand" href="https://www.isdcf.com/site/"><img src="{{#ifnoteq pageTemplate "index"}}../{{/ifnoteq}}ISDCF-logo.png" width="100"></a>
+    <a class="navbar-brand" href="https://www.isdcf.com/site/"><img src="{{#ifnoteq pageTemplate "index"}}../{{/ifnoteq}}ISDCF-logo.png" width="100" alt="ISDCF"></a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse site-menu" id="navbarNav">
       <ul class="navbar-nav ml-auto navbar-right">
         <li class="nav-item main-nav dropdown">
-          <a class="nav-link" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link" href="#" id="navbarDropdown1" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Home <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-chevron-double-down" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M1.646 6.646a.5.5 0 0 1 .708 0L8 12.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/><path fill-rule="evenodd" d="M1.646 2.646a.5.5 0 0 1 .708 0L8 8.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/></svg>
           </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown1">
             <a class="dropdown-item" href="https://www.isdcf.com/site/">Welcome</a>
             <a class="dropdown-item" href="https://www.isdcf.com/site/about/">About</a>
             <a class="dropdown-item" href="https://www.isdcf.com/site/terms/">Agreement of Terms</a>
           </div>
         </li>
         <li class="nav-item main-nav dropdown">
-          <a class="nav-link" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link" href="#" id="navbarDropdown2" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Meetings <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-chevron-double-down" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M1.646 6.646a.5.5 0 0 1 .708 0L8 12.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/><path fill-rule="evenodd" d="M1.646 2.646a.5.5 0 0 1 .708 0L8 8.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/></svg>
           </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown2">
             <a class="dropdown-item" href="https://isdcf.com/site/meetings/">Meetings</a>
             <a class="dropdown-item" href="https://www.isdcf.com/site/meeting-notes/about/">Meeting Notes</a>
             <a class="dropdown-item" href="https://www.isdcf.com/site/subgroups/">ISDCF SubGroups</a>
@@ -47,10 +47,10 @@
           </div>
         </li>
         <li class="nav-item main-nav dropdown">
-          <a class="nav-link" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link" href="#" id="navbarDropdown3" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Technical Details <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-chevron-double-down" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M1.646 6.646a.5.5 0 0 1 .708 0L8 12.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/><path fill-rule="evenodd" d="M1.646 2.646a.5.5 0 0 1 .708 0L8 8.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/></svg>
           </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown3">
             <a class="dropdown-item" href="https://www.isdcf.com/site/technical-docs/">Technical Docs</a>
             <a class="dropdown-item" href="https://www.isdcf.com/site/test-content/">Test Content</a>
             <a class="dropdown-item" href="https://www.isdcf.com/site/smpte-dcp-tests/">SMPTE DCP Tests</a>
@@ -83,12 +83,12 @@
     {{/ifeq}}
   {{/ifeq}}
   {{#ifeq menuLevel "2"}}
-    {{#ifeq pageType "menuBreak"}}
+    {{#ifeq pageType "menuCollapse"}}
           <li>
-            <a href="#{{pageTitle}}Submenu" data-toggle="collapse" aria-expanded="true" class="nav-link">{{pageTitle}} <svg width="1em" height="1em" viewBox="0 0 16 16" class="float-right bi bi-chevron-double-down" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M1.646 6.646a.5.5 0 0 1 .708 0L8 12.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/><path fill-rule="evenodd" d="M1.646 2.646a.5.5 0 0 1 .708 0L8 8.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/></svg></a>
-            <ul class="collapse list-unstyled" id="{{pageTitle}}Submenu">
+            <a href="#{{pageTemplate}}" data-toggle="collapse" aria-expanded="true" class="nav-link">{{pageTitle}} <svg width="1em" height="1em" viewBox="0 0 16 16" class="float-right bi bi-chevron-double-down" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M1.646 6.646a.5.5 0 0 1 .708 0L8 12.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/><path fill-rule="evenodd" d="M1.646 2.646a.5.5 0 0 1 .708 0L8 8.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/></svg></a>
+            <ul class="collapse list-unstyled" id="{{pageTemplate}}">
     {{/ifeq}}
-    {{#ifeq pageType "menuBreakEnd"}}
+    {{#ifeq pageType "menuCollapseEnd"}}
             </ul>
           </li>
     {{/ifeq}}

--- a/src/main/templates/projectoraspectratios.hbs
+++ b/src/main/templates/projectoraspectratios.hbs
@@ -29,16 +29,28 @@
                   {{description}}
                 </td>
                 <td>
-                  <code class="sampCode">
-                    <div class="border-bottom p-2">For 2K: "<code>{{cplMetadata/2K/ScreenAspectRatio}}</code>"</div>
-                    <div class="p-2">For 4K: "<code>{{cplMetadata/4K/ScreenAspectRatio}}</code>"</div>
-                  </code>
+                  <div class="border-bottom p-2">
+                    <code class="sampCode">
+                      For 2K: "<code>{{cplMetadata/2K/ScreenAspectRatio}}</code>"
+                    </code>
+                  </div>
+                  <div class="p-2">
+                    <code class="sampCode">
+                      For 4K: "<code>{{cplMetadata/4K/ScreenAspectRatio}}</code>"
+                    </code>
+                  </div>
                 </td>
                 <td>
-                  <code class="sampCode">
-                    <div class="border-bottom p-2">For 2k, Height: "<code>{{cplMetadata/2K/MainPictureStoredArea/Height}}</code>", Width: "<code>{{cplMetadata/2K/MainPictureStoredArea/Width}}</code>"</div>
-                    <div class="p-2">For 4K, Height: "<code>{{cplMetadata/4K/MainPictureStoredArea/Height}}</code>", Width: "<code>{{cplMetadata/4K/MainPictureStoredArea/Width}}</code>"</div>
-                  </code>
+                  <div class="border-bottom p-2">
+                    <code class="sampCode">
+                      For 2k, Height: "<code>{{cplMetadata/2K/MainPictureStoredArea/Height}}</code>", Width: "<code>{{cplMetadata/2K/MainPictureStoredArea/Width}}</code>"
+                    </code>
+                  </div>
+                  <div class="p-2">
+                    <code class="sampCode">
+                      For 4K, Height: "<code>{{cplMetadata/4K/MainPictureStoredArea/Height}}</code>", Width: "<code>{{cplMetadata/4K/MainPictureStoredArea/Width}}</code>"
+                    </code>
+                  </div>
                 </td>
                 <td>
                   {{#cplMetadata/definingDocs}}

--- a/src/main/templates/ratings.hbs
+++ b/src/main/templates/ratings.hbs
@@ -11,7 +11,7 @@
                 <th scope="col" class="align-text-top">Region</th>
                 <th scope="col" class="align-text-top">DCNC Code<br><small>(For CTT)</small></th>
                 <th scope="col" class="align-text-top">Rating Label Value<br><small>(For DCP Metadata)</small></th>
-                <th scope="col" class="align-text-top">Rating Agency Value<br><small>(For DCP Metadata)</small></th>
+                <th scope="col" class="align-text-top col-4">Rating Agency Value<br><small>(For DCP Metadata)</small></th>
                 <th scope="col" class="align-text-top">Rating Agency</th>
                 <th scope="col" class="align-text-top">Usage</th>
                 <th scope="col" class="align-text-top">Reference</th>
@@ -19,7 +19,7 @@
             </thead>
             <tbody id="searchTable">
               {{#data}}
-              <tr id="{{../idType}}-{{rfc5646Tag}}">
+              <tr id="{{../idType}}-{{stripillegalChars agency/identifier}}-{{stripillegalChars region/code}}">
                 <td>
                   {{region/name}} ({{region/code}})
                 </td>
@@ -41,7 +41,7 @@
                 </td>
                 <td class="use">
                   {{#use}}
-                  <p class="badge badge-secondary">{{this}}</p>
+                  <span class="badge badge-secondary">{{this}}</span>
                   {{/use}}
                 </td>
                 <td>

--- a/src/main/templates/studios.hbs
+++ b/src/main/templates/studios.hbs
@@ -8,8 +8,8 @@
           <table id="sorttable" class="table table-small table-hover display">
             <thead class="thead-light">
               <tr> 
-                <th scope="col" class="align-text-top" width="4em">Code</th>
-                <th scope="col" class="align-text-top">Description</th>
+                <th scope="col" class="align-text-top col-1">Code</th>
+                <th scope="col" class="align-text-top col-4">Description</th>
                 <th scope="col" class="align-text-top">Contact Info</th>
               </tr>
             </thead>

--- a/src/main/templates/territories.hbs
+++ b/src/main/templates/territories.hbs
@@ -12,12 +12,12 @@
                 <th scope="col" class="align-text-top">DCNC Code<br><small>(For CTT)</small></th>
                 <th scope="col" class="align-text-top">ReleaseTerritory Tag<br><small>(For DCP Metadata)</small></th>
                 <th scope="col" class="align-text-top">Tag Scope<br><small>(For DCP Metadata)</small></th>
-                <th scope="col" class="align-text-top text-wrap" width="20%">Notes</th>
+                <th scope="col" class="align-text-top text-wrap col-2">Notes</th>
               </tr>
             </thead>
             <tbody id="searchTable">
               {{#data}}
-              <tr id="{{../idType}}-{{rfc5646Tag}}">
+              <tr id="{{../idType}}-{{tag}}">
                 <td>
                   <span class="description">{{dcncTerritory}}</span>
                 </td>
@@ -29,7 +29,7 @@
                   {{/if}}
                 </td>
                 <td class="rfc">
-                  <a class="anchor" id="{{rfc5646Tag}}" href="#{{rfc5646Tag}}"></a><code>{{tag}}</code>
+                  <a class="anchor" id="{{tag}}" href="#{{tag}}"></a><code>{{tag}}</code>
                 </td>
                 <td class="cell-breakAll">
                   {{#if tagScope}}

--- a/src/main/templates/uls.hbs
+++ b/src/main/templates/uls.hbs
@@ -10,14 +10,14 @@
               <tr>
                 <th scope="col" class="align-text-top">Usage</th>
                 <th scope="col" class="align-text-top">Name</th>
-                <th scope="col" class="align-text-top" width="25%">UL</th>
+                <th scope="col" class="align-text-top col-2">UL</th>
                 <th scope="col" class="align-text-top">Defining Document(s)</th>
                 <th scope="col" class="align-text-top">Notes</th>
               </tr>
             </thead>
             <tbody id="searchTable">
               {{#data}}
-              <tr id="{{../idType}}">
+              <tr id="{{../idType}}-{{stripillegalChars ul}}">
                 <td>
                   {{usage}}
                 </td>


### PR DESCRIPTION
Fix HTML rendering errors, id, anchors, and similar tweaks. No changes to pages. 

Closes #33 

Note: only thing that now shows is a warning for the footnotes sections from MD rendering. Not critical. 