### PR TITLE
roll up Territory schema version by 0.0.1

### DIFF
--- a/src/main/scripts/build.js
+++ b/src/main/scripts/build.js
@@ -181,7 +181,7 @@ const pages = [
     "pageTemplate": "territories",
     "idType": "territory",
     "pageTitle": "Territory Codes",
-    "schemaBuild": "1.0.1",
+    "schemaBuild": "1.0.2",
     "menuLevel": 3,
     "breadCrumb": [
       "Naming Convention"


### PR DESCRIPTION
Update as per last update to Registry to account for Unicode characters. 