### PR TITLE
Fix incorrect behaviour in metadata extension properties renderer

### DIFF
--- a/src/main/scripts/build.js
+++ b/src/main/scripts/build.js
@@ -516,6 +516,10 @@ async function buildPage ({ pageTemplate, pageType, idType, pageTitle, schemaBui
       return options.inverse(this);
     });
 
+    hb.registerHelper('or', function (a, b) {
+      return Boolean(a || b);
+    });
+
     hb.registerHelper('stripillegalChars', function (a, b, options) {
       var cleanString = a.replace(/([^a-z0-9]+)/gi, '');
       return cleanString

--- a/src/main/templates/contentmodifiers.hbs
+++ b/src/main/templates/contentmodifiers.hbs
@@ -51,12 +51,14 @@
                   {{#ifeq cplMetadata/metaType "Extension Present"}}
                     &lt;cpl-meta:ExtensionMetadata scope="<code>{{cplMetadata/extScope}}</code>"&gt;<br>
                     &nbsp;&nbsp;&lt;cpl-meta:Name&gt;<code>{{cplMetadata/extName}}</code>&lt;/cpl-meta:Name&gt;<br>
+                    {{#if (or cplMetadata/extpropName cplMetadata/extpropValue)}}
                     &nbsp;&nbsp;&lt;cpl-meta:PropertyList&gt;<br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;cpl-meta:Property&gt;<br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;cpl-meta:Name&gt;<code>{{cplMetadata/extpropName}}</code>&lt;/cpl-meta:Name&gt;<br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;cpl-meta:Value&gt;<code>{{cplMetadata/extpropValue}}</code>&lt;/cpl-meta:Value&gt;<br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;/cpl-meta:Property&gt;<br>
                     &nbsp;&nbsp;&lt;/cpl-meta:PropertyList&gt;<br>
+                    {{/if}}
                     &lt;/cpl-meta:ExtensionMetadata&gt;
                     {{/ifeq}}
                   </code>

--- a/src/main/templates/cplmetadataexts.hbs
+++ b/src/main/templates/cplmetadataexts.hbs
@@ -25,12 +25,14 @@
                   <code class="sampCode">
                     &lt;cpl-meta:ExtensionMetadata scope="<code>{{extension/extScope}}</code>"&gt;<br>
                     &nbsp;&nbsp;&lt;cpl-meta:Name&gt;<code>{{extension/extName}}</code>&lt;/cpl-meta:Name&gt;<br>
+                    {{#if (or extension/extpropName extension/extpropValue)}}
                     &nbsp;&nbsp;&lt;cpl-meta:PropertyList&gt;<br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;cpl-meta:Property&gt;<br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;cpl-meta:Name&gt;<code>{{extension/extpropName}}</code>&lt;/cpl-meta:Name&gt;<br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;cpl-meta:Value&gt;<code>{{extension/extpropValue}}</code>&lt;/cpl-meta:Value&gt;<br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;/cpl-meta:Property&gt;<br>
                     &nbsp;&nbsp;&lt;/cpl-meta:PropertyList&gt;<br>
+                    {{/if}}
                     &lt;/cpl-meta:ExtensionMetadata&gt;
                   </code>
                 </td>


### PR DESCRIPTION
Fix incorrect behaviour in metadata extension properties renderer to close ISDCF/new-site#17.

Revised Content Modifiers template `contentmodifiers.hbs` and CPL Metadata Extension templates `cplmetadataexts.hbs` to only render the PropertyList block when a Property Name or Value exist, reflecting the respective definitions from `ST 429-16`